### PR TITLE
Modified ETL script to update existing Committee records.

### DIFF
--- a/sunshine/templates/committee-detail.html
+++ b/sunshine/templates/committee-detail.html
@@ -230,6 +230,7 @@
 
             <table class='table'
                 <tbody>
+                    {% if committee.active %}
                     <tr>
                         <td>Address</td>
                         <td>
@@ -246,6 +247,7 @@
                             {{ committee.zipcode }}
                         </td>
                     </tr>
+                    {% endif %}
                     {% if committee.creation_date %}
                     <tr>
                         <td>Founded</td>

--- a/sunshine/templates/contested-race-detail.html
+++ b/sunshine/templates/contested-race-detail.html
@@ -4,6 +4,10 @@
     {{ header(contested_races_title, contested_races_type | contested_races_description, request.path) }}
 {% endblock %}
 {% block content %}
+<style>
+    body { color: #000; }
+    h2 small { color: #000; }
+</style>
 
 <h1><i class='fa fa-flag-checkered'></i> {% if district %}District {{ district }} - {% endif %}Contested Race<small>{% if contested_race_type %} <strong>{{ contested_race_type }}</strong>{% endif %}, updated daily</small></h1>
 <div class="row">

--- a/sunshine/views.py
+++ b/sunshine/views.py
@@ -664,11 +664,12 @@ def contested_race_detail(race_type, district):
     district = int(float(district))
 
     contested_races_sql = '''
-        SELECT *
-        FROM contested_races
-        WHERE district = :district
-          AND branch = :branch
-        ORDER BY last_name, first_name
+        SELECT cr.*, c.name as committee_committee_name
+        FROM contested_races cr
+        LEFT JOIN committees c ON (c.id = cr.committee_id)
+        WHERE cr.district = :district
+          AND cr.branch = :branch
+        ORDER BY cr.last_name, cr.first_name
     '''
 
     races = list(g.engine.execute(sa.text(contested_races_sql),district=district,branch=branch))
@@ -682,9 +683,9 @@ def contested_race_detail(race_type, district):
         total_money += race.supporting_funds + race.opposing_funds
 
         if race.incumbent == 'N':
-            contested_races.append({'table_display_data': committee_funds_data, 'primary_funds_raised': primary_funds_raised, 'last': race.last_name, 'first': race.first_name,'committee_name': race.committee_name,'incumbent': race.incumbent,'committee_id': race.committee_id,'party': race.party,'investments': race.investments, 'debts': race.debts, 'supporting_funds': race.supporting_funds, 'opposing_funds': race.opposing_funds, 'contributions' : race.contributions, 'total_funds' : race.total_funds, 'funds_available' : race.funds_available, 'total_money' : race.total_money, 'candidate_id' : race.candidate_id, 'reporting_period_end' : race.reporting_period_end})
+            contested_races.append({'table_display_data': committee_funds_data, 'primary_funds_raised': primary_funds_raised, 'last': race.last_name, 'first': race.first_name,'committee_name': race.committee_committee_name if race.committee_committee_name else race.committee_name,'incumbent': race.incumbent,'committee_id': race.committee_id,'party': race.party,'investments': race.investments, 'debts': race.debts, 'supporting_funds': race.supporting_funds, 'opposing_funds': race.opposing_funds, 'contributions' : race.contributions, 'total_funds' : race.total_funds, 'funds_available' : race.funds_available, 'total_money' : race.total_money, 'candidate_id' : race.candidate_id, 'reporting_period_end' : race.reporting_period_end})
         else:
-            contested_races.insert(0,{'table_display_data': committee_funds_data, 'primary_funds_raised': primary_funds_raised, 'last': race.last_name, 'first': race.first_name,'committee_name': race.committee_name,'incumbent': race.incumbent,'committee_id': race.committee_id,'party': race.party,'investments': race.investments, 'debts': race.debts, 'supporting_funds': race.supporting_funds, 'opposing_funds': race.opposing_funds, 'contributions' : race.contributions, 'total_funds' : race.total_funds, 'funds_available' : race.funds_available, 'total_money' : race.total_money, 'candidate_id' : race.candidate_id, 'reporting_period_end' : race.reporting_period_end})
+            contested_races.insert(0,{'table_display_data': committee_funds_data, 'primary_funds_raised': primary_funds_raised, 'last': race.last_name, 'first': race.first_name,'committee_name': race.committee_committee_name if race.committee_committee_name else race.committee_name,'incumbent': race.incumbent,'committee_id': race.committee_id,'party': race.party,'investments': race.investments, 'debts': race.debts, 'supporting_funds': race.supporting_funds, 'opposing_funds': race.opposing_funds, 'contributions' : race.contributions, 'total_funds' : race.total_funds, 'funds_available' : race.funds_available, 'total_money' : race.total_money, 'candidate_id' : race.candidate_id, 'reporting_period_end' : race.reporting_period_end})
 
     return render_template(template,
                             race_type=race_type,


### PR DESCRIPTION
- Modified the ETL script to update existing Committee records.
- Modified the Contested Race Details page to use a black font color.
- Modified the Committee Details page to only show the address section for active committees.
- Updated the Contest Race Details page to pull the committee name for each candidate from the related Committee record, but to fall back to the committee name in the csv file if the connection to the specified committee record can't be found.